### PR TITLE
[BACK-2916/BACK-2913] Separate personal and clinical registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,8 @@ node_modules
 src/test/e2e/cypress/reports
 src/test/e2e/cypress/videos
 src/test/e2e/cypress/screenshots
+
+# Environment
+.env
+.envrc
+.java-version

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default: build
+
+.PHONY: clean
+clean:
+	mvn clean
+
+.PHONY: build
+build: target/keycloak-home-idp-discovery.jar
+
+target/keycloak-home-idp-discovery.jar: pom.xml $(shell find src -type f | sed 's/ /\\ /g')
+	mvn clean package --file pom.xml

--- a/src/main/java/de/sventorben/keycloak/services/messages/Messages.java
+++ b/src/main/java/de/sventorben/keycloak/services/messages/Messages.java
@@ -1,0 +1,9 @@
+package de.sventorben.keycloak.services.messages;
+
+public class Messages extends org.keycloak.services.messages.Messages {
+    
+    public static final String UNKNOWN_USERNAME = "unknownUsernameMessage";
+
+    public static final String UNKNOWN_EMAIL = "unknownEmailMessage";
+
+}

--- a/src/main/resources/theme-resources/messages/messages.properties
+++ b/src/main/resources/theme-resources/messages/messages.properties
@@ -1,3 +1,6 @@
 home-idp-discovery-display-name=Home identity provider
 home-idp-discovery-help-text=Sign in via your home identity provider which will be automatically determined based on your provided email address.
 home-idp-discovery-identity-provider-login-label=Select your home identity provider
+
+unknownUsernameMessage=Unknown username.
+unknownEmailMessage=Unknown email.

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,3 +1,6 @@
 home-idp-discovery-display-name=Home identity provider
 home-idp-discovery-help-text=Sign in via your home identity provider which will be automatically determined based on your provided email address.
 home-idp-discovery-identity-provider-login-label=Select your home identity provider
+
+unknownUsernameMessage=Unknown username.
+unknownEmailMessage=Unknown email.


### PR DESCRIPTION
- Display error if login username is not found nor linked with SSO
- Differentiate error message for empty username versus unknown username
- Add Makefile to standardize build
- https://tidepool.atlassian.net/browse/BACK-2916
- https://tidepool.atlassian.net/browse/BACK-2913

Note: We may want to create a Tidepool-specific "main" branch and merge in `check-email-matches-21` into that and rebase this PR against that new branch.